### PR TITLE
Add LFS for .mkv; add alpha4_video_update for future blog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.mkv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Recorded quick video showing the BoardEditor I created. Just raw .mkv via OBS clocking at a cool 40mb. 

40mb is le big. Too big for Git, but LFS exists so I followed the barebones tut for it from https://git-lfs.github.com/ and it should just work right? I'm tracking `.mkv` files so it should be fine? 